### PR TITLE
Make the requirements file readable by pip rather than a shell script.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-pip install flask==0.9
-pip install flask-login
-pip install flask-openid
-pip install flask-mail
-pip install sqlalchemy==0.7.9
-pip install flask-sqlalchemy==0.16
-pip install sqlalchemy-migrate
-pip install flask-whooshalchemy==0.54a
-pip install flask-wtf
-pip install pytz==2013b
-pip install flask-babel==0.8
-pip install flup
+flask==0.9
+flask-login
+flask-openid
+flask-mail
+sqlalchemy==0.7.9
+flask-sqlalchemy==0.16
+sqlalchemy-migrate
+flask-whooshalchemy==0.54a
+flask-wtf
+pytz==2013b
+flask-babel==0.8
+flup


### PR DESCRIPTION
So that you can just run

```
pip install -r requirements.txt
```
